### PR TITLE
Fixing issue where replies do not work for messages like '@bot hello'.

### DIFF
--- a/clients/slack.js
+++ b/clients/slack.js
@@ -65,6 +65,11 @@ var receiveData = function(slack, bot, data) {
   // Are they talking to us?
   if (match && match[1] === slack.self.id) {
 
+    message = message.replace(atReplyRE, '').trim();
+    if (message[0] == ':') {
+        message = message.substring(1).trim();
+    }
+
     bot.reply(user.name, message, function(err, reply){
       // We reply back direcly to the user
 
@@ -73,13 +78,15 @@ var receiveData = function(slack, bot, data) {
           channel = slack.getChannelGroupOrDMByName(user.name);
           break;
         case "atReply": 
-          reply = "@" + user.name  + " " + reply.string;
+          reply.string = "@" + user.name  + " " + reply.string;
+          channel = slack.getChannelGroupOrDMByID(messageData.channel);
+          break;
         case "public":
           channel = slack.getChannelGroupOrDMByID(messageData.channel);
           break
 
       }
-      if (reply) {
+      if (reply.string) {
         channel.send(reply.string);
       }
         


### PR DESCRIPTION
The bot will reply to direct messages, but mentions in group chat cause problems where there is no reply or the reply is blank. Stuff like '@bot: ' at the beginning of the message apparently prevents a match in bot.reply().

Fixed an issue on line 81 that looks like it was introduced when 'reply' was changed from a string to an object. The channel was not being set either. At that point in the code it was undefined. Finally, there was a missing break wasn't really an issue, but I added it so it doesn't become a problem later.