### PR TITLE
Added clean-up per topic, import from single file, original message preservation

### DIFF
--- a/bin/cleanup.js
+++ b/bin/cleanup.js
@@ -18,8 +18,8 @@ program
   .option('--facts [type]', 'Fact Directory', './systemDB')
   .option('--mongo [type]', 'Mongo Database Name', 'systemDB')
   .option('--topic [type]', 'Topic Directory', './topics')
-  .option('--remove-all', 'Remove collections: ' + collectionsToRemove.join(', '))
-  .option('--flush-topics', 'Flush topic gambits and replies')
+  .option('--skip-remove-all', 'Skip removal of: ' + collectionsToRemove.join(', '))
+  .option('--flush-topics', 'Flush imported topics, implies --skip-remove-all')
   .parse(process.argv);
 
 function removeAll (db) {
@@ -28,7 +28,7 @@ function removeAll (db) {
      * @return {Promise} Resolved after listed collections are removed and the fact system directory has been recursively cleared
      */
 
-    if (!program.removeAll) return;
+    if (program.skipRemoveAll || program.flushTopics) return;
 
     return Promise.map(collectionsToRemove, function(collName) {
             var coll = db.collection(collName);

--- a/bin/cleanup.js
+++ b/bin/cleanup.js
@@ -11,11 +11,15 @@ var Promise = require('bluebird'),
     superscript = require('../index'),
     fs = require("fs");
 
+var collectionsToRemove = ['users', 'topics', 'replies', 'gambits'];
+
 program
   .version('0.0.1')
   .option('--facts [type]', 'Fact Directory', './systemDB')
   .option('--mongo [type]', 'Mongo Database Name', 'systemDB')
   .option('--topic [type]', 'Topic Directory', './topics')
+  .option('--remove-all', 'Remove collections: ' + collectionsToRemove.join(', '))
+  .option('--flush-topics', 'Flush topic gambits and replies')
   .parse(process.argv);
 
 function removeAll (db) {
@@ -23,7 +27,8 @@ function removeAll (db) {
      * @param {Object} MongoDB instance
      * @return {Promise} Resolved after listed collections are removed and the fact system directory has been recursively cleared
      */
-    var collectionsToRemove = ['users', 'topics', 'replies', 'gambits'];
+
+    if (!program.removeAll) return;
 
     return Promise.map(collectionsToRemove, function(collName) {
             var coll = db.collection(collName);
@@ -60,11 +65,11 @@ function createFresh () {
          * @param {Object} Parsed data from a .ss file
          * @return {Promise} Resolved when import is complete
          */
-        
+
         // console.log('Importing', data);
         return new Promise(function(resolve, reject) {
             new superscript({factSystem: factSystem}, function(err, bot) {
-                if (!err) bot.topicSystem.importerData(data, resolve);
+                if (!err) bot.topicSystem.importerData(data, resolve, program.flushTopics);
                 else reject(err);
             });
         });

--- a/bin/cleanup.js
+++ b/bin/cleanup.js
@@ -56,7 +56,7 @@ function createFresh () {
 
     // Generate Shared Fact System
     // If not pre-generated, superscript will throw error on initialization
-    var factSystem = facts.create('systemDB'),
+    var factSystem = facts.create(program.facts),
         parser = require('../lib/parse')(factSystem),
         loadDirectory = Promise.promisify( parser.loadDirectory, parser );
 

--- a/index.js
+++ b/index.js
@@ -129,7 +129,8 @@ var messageFactory = function (rawMsg, question, normalize, facts, cb) {
     var messageOptions = {
       qtypes: question,
       norm: normalize,
-      facts: facts
+      facts: facts,
+      original: rawMsg
     };
 
     new Message(messageChunk.trim(), messageOptions, function (tmsg) {

--- a/lib/message.js
+++ b/lib/message.js
@@ -58,7 +58,9 @@ var Message = function (msg, options, cb) {
   self.facts = options.facts;
   self.createdAt = new Date();
   self.raw = cleanIncomming(msg);
+  self.original = options.original;
   self.props = {};
+
 
   self.clean = options.norm.clean(self.raw).trim();
   var wordArray = new pos.Lexer().lex(self.clean);

--- a/lib/topics/gambit.js
+++ b/lib/topics/gambit.js
@@ -12,6 +12,7 @@ module.exports = function (mongoose, facts) {
   var Utils = require("../utils");
   var regexreply = require("../parse/regexreply");
   var debug = require("debug")("Gambit");
+  var async = require("async");
   var norm = require("node-normalizer");
   var findOrCreate = require("mongoose-findorcreate");
   var gNormalizer;
@@ -116,6 +117,29 @@ module.exports = function (mongoose, facts) {
         match = message.lemString.match(compiledRE);
       }
       cb(null, match);
+    });
+  };
+
+  gambitSchema.methods.clearReplies = function (callback) {
+    var self = this;
+
+    var clearReply = function (replyId, cb) {
+      self.replies.pull({ _id: replyId });
+      Reply.remove({ _id: replyId }, function (err) {
+        if (err) {
+          console.log(err);
+        }
+
+        debug('removed reply ' + replyId);
+
+        cb(null, replyId);
+      });
+    };
+
+    async.map(self.replies, clearReply, function (err, clearedReplies) {
+      self.save(function (err2) {
+        callback(err2, clearedReplies);
+      });
     });
   };
 

--- a/lib/topics/import.js
+++ b/lib/topics/import.js
@@ -41,7 +41,7 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
     return gambitData;
   };
 
-  var importData = function (data, callback) {
+  var importData = function (data, callback, flushTopic) {
 
     var gambitsWithConversation = [];
 
@@ -71,6 +71,18 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
       };
     };
 
+    var getTopic = function (query, properties, callback) {
+      Topic.findOrCreate(query, properties, function (err, topic) {
+        if (flushTopic) {
+          topic.clearGambits(function(err) {
+            callback(err, topic);
+          });
+        } else {
+          callback(err, topic);
+        }
+      });
+    };
+
     var eachTopicItor = function (topicName, nextTopic) {
       debug("Find or create", topicName);
       var properties = {
@@ -80,7 +92,7 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
         keywords: data.topics[topicName].keywords ? data.topics[topicName].keywords : []
       };
 
-      Topic.findOrCreate({name: topicName}, properties, function (err, topic) {
+      getTopic({name: topicName}, properties, function (err, topic) {
         if (err) {
           console.log(err);
         }

--- a/lib/topics/import.js
+++ b/lib/topics/import.js
@@ -73,9 +73,25 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
 
     var getTopic = function (query, properties, callback) {
       Topic.findOrCreate(query, properties, function (err, topic) {
+        callback(err, topic);
+      });
+    };
+
+    var findOrCreateTopic = function (query, properties, callback) {
+      Topic.findOrCreate(query, properties, function (err, topic) {
         if (flushTopic) {
-          topic.clearGambits(function(err) {
-            callback(err, topic);
+          topic.clearGambits(function() {
+            Topic.remove({ _id: topic.id }, function (err2) {
+              if (err2) {
+                console.log(err);
+              }
+
+              debug('removed topic ' + topic.id);
+
+              Topic.findOrCreate(query, properties, function (err3, topic2) {
+                callback(err3, topic2);
+              });
+            });
           });
         } else {
           callback(err, topic);
@@ -92,7 +108,7 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
         keywords: data.topics[topicName].keywords ? data.topics[topicName].keywords : []
       };
 
-      getTopic({name: topicName}, properties, function (err, topic) {
+      findOrCreateTopic({name: topicName}, properties, function (err, topic) {
         if (err) {
           console.log(err);
         }

--- a/lib/topics/import.js
+++ b/lib/topics/import.js
@@ -71,12 +71,6 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
       };
     };
 
-    var getTopic = function (query, properties, callback) {
-      Topic.findOrCreate(query, properties, function (err, topic) {
-        callback(err, topic);
-      });
-    };
-
     var findOrCreateTopic = function (query, properties, callback) {
       Topic.findOrCreate(query, properties, function (err, topic) {
         if (flushTopic) {

--- a/lib/topics/import.js
+++ b/lib/topics/import.js
@@ -41,7 +41,7 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
     return gambitData;
   };
 
-  var importData = function (data, callback, flushTopic) {
+  var importData = function (data, callback, flushTopics) {
 
     var gambitsWithConversation = [];
 
@@ -73,7 +73,7 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
 
     var findOrCreateTopic = function (query, properties, callback) {
       Topic.findOrCreate(query, properties, function (err, topic) {
-        if (flushTopic) {
+        if (flushTopics) {
           topic.clearGambits(function() {
             Topic.remove({ _id: topic.id }, function (err2) {
               if (err2) {

--- a/lib/topics/topic.js
+++ b/lib/topics/topic.js
@@ -349,6 +349,37 @@ module.exports = function (mongoose) {
     );
   };
 
+  topicSchema.methods.clearGambits = function (callback) {
+    var self = this;
+
+    var clearGambit = function (gambitId, cb) {
+      self.gambits.pull({ _id: gambitId });
+      Gambit.findById(gambitId, function (err, gambit) {
+        if (err) {
+          console.log(err);
+        }
+
+        gambit.clearReplies(function() {
+          Gambit.remove({ _id: gambitId }, function (err) {
+            if (err) {
+              console.log(err);
+            }
+
+            debug('removed gambit ' + gambitId);
+
+            cb(null, gambitId);
+          });
+        });
+      });
+    };
+
+    async.map(self.gambits, clearGambit, function (err, clearedGambits) {
+      self.save(function (err2) {
+        callback(err2, clearedGambits);
+      });
+    });
+  };
+
   // This will find a gambit in any topic
   topicSchema.statics.findTriggerByTrigger = function (input, callback) {
     Gambit.findOne({input: input}).exec(callback);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -202,6 +202,11 @@ exports.genId = function () {
 
 
 var walk = function (dir, done) {
+
+  if (fs.statSync(dir).isFile()) {
+    return done(null, [dir]);
+  }
+
   var results = [];
   fs.readdir(dir, function (err1, list) {
     if (err1) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -204,6 +204,7 @@ exports.genId = function () {
 var walk = function (dir, done) {
 
   if (fs.statSync(dir).isFile()) {
+    debug('Expected directory, found file, simulating directory with only one file: ' + dir)
     return done(null, [dir]);
   }
 


### PR DESCRIPTION
Added `Gambit.clearReplies` which deletes all the gambit's replies.

Added `Topic.clearGambits` which deletes all the topic's gambits (and each gambit's replies).

Modified `lib/topics/import.js` to accept an extra parameter to clear and a remove a topic (via the above `Topic.clearGambits`), parameter fed from the clean-up script:

Added to `bin/cleanup.js` (/cc @neekolas)
* a cli option `--skip-remove-all` to skip database clean-up 
* a cli option `--flush-topics` to flush topics alone (incl. their gambits and replies) at import

Fixed in `bin/cleanup.js`
* create fact system based on `--facts` input (it was only using that data to remove the folder, the factSystem was always `systemDB`)

Made `Utils.walk` accept a file path instead of a directory (will simulate a directory with that single file) in order to allow the import of single files not just folders.
[We use that in conjunction with the `--flush-topics` option such that every change on a topic file will trigger an import of that content alone (we trigger it via gulp watch)]

Preserve original message to message object before storing.
