### PR TITLE
added '--preserve-random', to be used with `--flush-topics` to avoid …

### DIFF
--- a/bin/cleanup.js
+++ b/bin/cleanup.js
@@ -20,6 +20,7 @@ program
   .option('--topic [type]', 'Topic Directory', './topics')
   .option('--skip-remove-all', 'Skip removal of: ' + collectionsToRemove.join(', '))
   .option('--flush-topics', 'Flush imported topics, implies --skip-remove-all')
+  .option('--preserve-random', 'When used with --flush-topics, it will not empty the random topic')
   .parse(process.argv);
 
 function removeAll (db) {
@@ -69,7 +70,7 @@ function createFresh () {
         // console.log('Importing', data);
         return new Promise(function(resolve, reject) {
             new superscript({factSystem: factSystem}, function(err, bot) {
-                if (!err) bot.topicSystem.importerData(data, resolve, program.flushTopics);
+                if (!err) bot.topicSystem.importerData(data, resolve, program.flushTopics, program.preserveRandom);
                 else reject(err);
             });
         });

--- a/lib/topics/import.js
+++ b/lib/topics/import.js
@@ -41,7 +41,7 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
     return gambitData;
   };
 
-  var importData = function (data, callback, flushTopics) {
+  var importData = function (data, callback, flushTopics, preserveRandom) {
 
     var gambitsWithConversation = [];
 
@@ -71,18 +71,18 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
       };
     };
 
-    var findOrCreateTopic = function (query, properties, callback) {
-      Topic.findOrCreate(query, properties, function (err, topic) {
-        if (flushTopics) {
+    var findOrCreateTopic = function (topicName, properties, callback) {
+      Topic.findOrCreate({name: topicName}, properties, function (err, topic) {
+        if (flushTopics && !(topicName === 'random' && preserveRandom)) {
           topic.clearGambits(function() {
             Topic.remove({ _id: topic.id }, function (err2) {
               if (err2) {
                 console.log(err);
               }
 
-              debug('removed topic ' + topic.id);
+              debug('removed topic ' + topicName + ' (' + topic.id + ')');
 
-              Topic.findOrCreate(query, properties, function (err3, topic2) {
+              Topic.findOrCreate({name: topicName}, properties, function (err3, topic2) {
                 callback(err3, topic2);
               });
             });
@@ -102,7 +102,7 @@ module.exports = function (factSystem, Topic, Gambit, Reply) {
         keywords: data.topics[topicName].keywords ? data.topics[topicName].keywords : []
       };
 
-      findOrCreateTopic({name: topicName}, properties, function (err, topic) {
+      findOrCreateTopic(topicName, properties, function (err, topic) {
         if (err) {
           console.log(err);
         }


### PR DESCRIPTION
When importing a single file with `--flush-topics`, the `random` topic will be emptied even if the file does not define that topic (apparently the `random` topic gets created by default). The added `--preserve-random` option will skip the flushing of the `random` topic.

Note that for loading a file in `--flush-topics` mode that actually defines the `random` topic you will have to skip the `--preserve-random` option.