### PR TITLE
Modify reply alternate syntax

### DIFF
--- a/lib/processtags.js
+++ b/lib/processtags.js
@@ -91,7 +91,6 @@ var parseCustomFunctions = function (reply, plugins, scope, callback) {
 
 var processAlternates = function (reply) {
   // Reply Alternates.
-  // var match = reply.match(/\((.+?)\)/);
   var match = reply.match(/\(\((.+?)\)\)/);
   var giveup = 0;
   while (match) {
@@ -109,10 +108,8 @@ var processAlternates = function (reply) {
       opts.push(parts[i].trim());
     }
 
-    var resp = getRandomInt(0, opts.length - 1);
-    // reply = reply.replace(new RegExp("\\(" + quotemeta(match[1]) + "\\)\\s*"), opts[resp]);
-    reply = reply.replace(new RegExp("\\(\\(\\s*" + quotemeta(match[1]) + "\\s*\\)\\)"), opts[resp]);
-    // match = reply.match(/\((.+?)\)/);
+    var resp = Utils.getRandomInt(0, opts.length - 1);
+    reply = reply.replace(new RegExp("\\(\\(\\s*" + Utils.quotemeta(match[1]) + "\\s*\\)\\)"), opts[resp]);
     match = reply.match(/\(\((.+?)\)\)/);
   }
 
@@ -219,7 +216,7 @@ module.exports = function (replyObj, user, options, callback) {
         var getreply = require("./getreply");
         var target = redirectMatch[1];
         debug("Inline redirection to: '" + target + "'");
-        
+
         var messageOptions = {
           qtypes: gQtypes,
           norm: gNormalize,
@@ -229,7 +226,7 @@ module.exports = function (replyObj, user, options, callback) {
         getTopic(replyObj.topic, function (err, topicData) {
           options.aTopics = [];
           options.aTopics.push(topicData);
-        
+
           new Message(target, messageOptions, function (replyMessageObject) {
             options.message = replyMessageObject;
             getreply(options, function (err, subreply) {
@@ -414,7 +411,7 @@ module.exports = function (replyObj, user, options, callback) {
         var getreply = require("./getreply");
         var newTopic = Utils.trim(respondMatch[1]);
         debug("Topic Check with new Topic: " + newTopic);
-        
+
         getTopic(replyObj.topic, function (err, topicData) {
 
           options.aTopics = [];

--- a/lib/processtags.js
+++ b/lib/processtags.js
@@ -91,7 +91,8 @@ var parseCustomFunctions = function (reply, plugins, scope, callback) {
 
 var processAlternates = function (reply) {
   // Reply Alternates.
-  var match = reply.match(/\((.+?)\)/);
+  // var match = reply.match(/\((.+?)\)/);
+  var match = reply.match(/\(\((.+?)\)\)/);
   var giveup = 0;
   while (match) {
     debug("Reply has Alternates");
@@ -108,9 +109,11 @@ var processAlternates = function (reply) {
       opts.push(parts[i].trim());
     }
 
-    var resp = Utils.getRandomInt(0, opts.length - 1);
-    reply = reply.replace(new RegExp("\\(" + Utils.quotemeta(match[1]) + "\\)\\s*"), opts[resp]);
-    match = reply.match(/\((.+?)\)/);
+    var resp = getRandomInt(0, opts.length - 1);
+    // reply = reply.replace(new RegExp("\\(" + quotemeta(match[1]) + "\\)\\s*"), opts[resp]);
+    reply = reply.replace(new RegExp("\\(\\(\\s*" + quotemeta(match[1]) + "\\s*\\)\\)"), opts[resp]);
+    // match = reply.match(/\((.+?)\)/);
+    match = reply.match(/\(\((.+?)\)\)/);
   }
 
   return reply;

--- a/test/fixtures/script/script.ss
+++ b/test/fixtures/script/script.ss
@@ -2,7 +2,7 @@
 
   + + this is unscaped
   - This should pass
-  
+
   + * bone *
   - {keep} win 1
 
@@ -22,7 +22,7 @@
 
   /*
     Variable length Star
-    *2 will match exactly 2 
+    *2 will match exactly 2
     *~2 will match 0,2
   */
   // Should match it is foo bar hot out
@@ -48,7 +48,7 @@
   - {keep} min max test
 
 
-  // Test 2 Star match 
+  // Test 2 Star match
   + It is *2 cold out
   - Two star result <cap>
 
@@ -82,12 +82,12 @@
   - Test seven should pass
 
   + this reply is random
-  - yes this reply is (awesome|random)
+  - yes this reply is ((awesome|random))
 
   + reply with wordnet
   - i ~like people
 
-  // In this example we want to demonstrate that the trigger 
+  // In this example we want to demonstrate that the trigger
   // is changed to "it is ..." before trying to find a match
   + it's all good in the hood
   - normalize trigger test
@@ -247,7 +247,7 @@
 ^ Is not in the picture today.
 
 
-// In this example we want to demonstrate that the trigger 
+// In this example we want to demonstrate that the trigger
 // is changed to "it is ..." before trying to find a match
 + it's all good in the hood
 - normalize trigger test


### PR DESCRIPTION
Modified alternates syntax in replies to use double parenthesis:
`(one|two|three)` -> `((one|two|three))`