### PR TITLE
Special topics inline redirection

### DIFF
--- a/lib/reply/inlineRedirect.js
+++ b/lib/reply/inlineRedirect.js
@@ -5,7 +5,7 @@ var async = require("async");
 var debug = require("debug")("Reply:inline");
 
 module.exports = function(reply, redirectMatch, options, callback) {
-  
+
   var messageOptions = {
     qtypes: options.system.question,
     norm: options.system.normalize,
@@ -17,9 +17,17 @@ module.exports = function(reply, redirectMatch, options, callback) {
       return redirectMatch;
     },
     function (cb) {
-      
+
       var target = redirectMatch[1];
       debug("Inline redirection to: '" + target + "'");
+
+      // if we have a special topic, reset it to the previous one
+      // in order to preserve the context for inline redirection
+      if (options.topic === "__pre__" || options.topic === "__post__") {
+        if (options.user.__history__.topic.length) {
+          options.topic = options.user.__history__.topic[0];
+        }
+      }
 
       processHelpers.getTopic(options.system.topicsSystem, options.topic, function (err, topicData) {
         options.aTopics = [];

--- a/test/fixtures/script/script.ss
+++ b/test/fixtures/script/script.ss
@@ -278,3 +278,17 @@
   + how many colors in the rainbow
   - {delay=500} lots
 < topic
+
+
+// Special topics flow with inline redirection
+> topic __pre__
+  + flow redirection test
+  - Going back. {@first flow match}
+< topic
+
+> topic flow_test
+  + first flow match
+  - {keep} You are in the first reply.
+  + second flow match
+  - You are in the second reply. {@first flow match}
+< topic

--- a/test/script.js
+++ b/test/script.js
@@ -155,7 +155,7 @@ describe.only('SuperScript Scripting + Style Interface', function(){
     //     done();
     //   });
     // });
-    
+
   });
 
   describe('Variable length star interface *~n', function() {
@@ -381,7 +381,7 @@ describe.only('SuperScript Scripting + Style Interface', function(){
 
         var r = { string: 'red',
           topicName: 'rainbow',
-          subReplies: 
+          subReplies:
            [ { delay: '500', string: 'orange' },
              { delay: '500', string: 'yellow' },
              { delay: '500', string: 'green' },
@@ -398,16 +398,16 @@ describe.only('SuperScript Scripting + Style Interface', function(){
 
         var r = { string: '',
           topicName: 'rainbow',
-          subReplies: 
+          subReplies:
            [ { delay: '500', string: 'lots' } ] };
 
         reply.should.containDeep(r);
         done();
       });
     });
-    
 
-  
+
+
   });
 
 
@@ -680,14 +680,14 @@ describe.only('SuperScript Scripting + Style Interface', function(){
         reply.string.should.eql("normalize trigger test");
         done();
       });
-    });   
+    });
 
     it("should be expanded before trying to match contract form", function(done){
       bot.reply("user1", "it's all good in the hood two", function(err, reply) {
         reply.string.should.eql("normalize trigger test");
         done();
       });
-    });   
+    });
   });
 
   describe('Mix case test', function(){
@@ -762,6 +762,31 @@ describe.only('SuperScript Scripting + Style Interface', function(){
       bot.reply("user1", "My name is Bill. What is your name?", function(err, reply) {
         reply.string.should.eql("Hi Bill. My name is Brit.");
         done();
+      });
+    });
+  });
+
+
+  describe('Keep the current topic when a special topic is matched', function(){
+    it("Should redirect to the first gambit", function(done) {
+      bot.reply("user1", "first flow match", function(err, reply) {
+        reply.string.should.eql("You are in the first reply.");
+
+        bot.reply("user1", "second flow match", function(err, reply) {
+          reply.string.should.eql("You are in the second reply. You are in the first reply.");
+          done();
+        });
+      });
+    });
+
+    it("Should redirect to the first gambit after matching __pre__", function(done) {
+      bot.reply("user1", "first flow match", function(err, reply) {
+        reply.string.should.eql("You are in the first reply.");
+
+        bot.reply("user1", "flow redirection test", function(err, reply) {
+          reply.string.should.eql("Going back. You are in the first reply.");
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
Per discussion on Slack, update inlineRedirect to account for the special `pre` and `post` topics, so we can preserve/support inline redirection towards the topic we were in before the match.